### PR TITLE
Fix autofocus in searchbox

### DIFF
--- a/src/components/Searchbox.js
+++ b/src/components/Searchbox.js
@@ -81,7 +81,6 @@ const Searchbox = props => {
   }, [])
   return (
     <StyledSearchbox
-      autoFocus
       submit={<MagnifyingGlass width={20} />}
       reset={<Cross width={11} />}
       translations={{


### PR DESCRIPTION

Searchbox is automatically focused when entering the page, causing an unwanted scroll. This PR fixes it.