### PR TITLE
Update cloud plan on pricing hero

### DIFF
--- a/data/pricing.js
+++ b/data/pricing.js
@@ -43,8 +43,8 @@ const getPricingPageData = () => ({
           title: 'Dedicated',
           description: 'For production applications.<br/>Starting from ',
           tooltip: {
-            cta: '$30/month',
-            text: 'Estimation based on $0.042 per hour.',
+            cta: '$29/month',
+            text: 'Estimation based on $0.040 per hour.',
           },
           keypoints: [
             'Highly available by default',


### PR DESCRIPTION
The pricing on the Hero of the `pricing` page is wrong. This PR updates it.