### PR TITLE
Update instant meilisearch to v0.8.1 & update index name for interactive search

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@meilisearch/instant-meilisearch": "^0.5.10",
+    "@meilisearch/instant-meilisearch": "^0.8.1",
     "@octokit/rest": "^19.0.3",
     "@segment/analytics-next": "^1.41.1",
     "gray-matter": "^4.0.3",

--- a/src/components/InteractiveSearch.js
+++ b/src/components/InteractiveSearch.js
@@ -144,7 +144,7 @@ const InteractiveSearch = ({
           ariaLabel="animated arrows"
         />
       </Animation>
-      <InstantSearch indexName="movies" searchClient={searchClient}>
+      <InstantSearch indexName="movies-en-US" searchClient={searchClient}>
         <Searchbox placeholderSearch={placeholderSearch} />
         <Stats
           translations={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,12 +1447,12 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
-"@meilisearch/instant-meilisearch@^0.5.10":
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/@meilisearch/instant-meilisearch/-/instant-meilisearch-0.5.10.tgz#c65cf42895f88b75bef7fe64c3f7f8c92e646261"
-  integrity sha512-8AUxx+o9l+Jv/l54URhKeHWl4zOIySbuWwcIOXJId9+vGiig+uDekUYXmEc5BLe6O3hr6cF/Gg8Rrli8PLYHVw==
+"@meilisearch/instant-meilisearch@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@meilisearch/instant-meilisearch/-/instant-meilisearch-0.8.1.tgz#a9d1d7b39fc26c4f3a90fde79126957b3db57824"
+  integrity sha512-oiRkxcxW1gmAedX17vmQExjjeEOq+hd0jsrVWX7Hn8zMNr0i/fMTKcW2mrv7oTc30RA4xV86aeAM6g3rmOnutg==
   dependencies:
-    meilisearch "^0.23.0"
+    meilisearch "^0.27.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -5763,7 +5763,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.1.4:
+cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -9099,12 +9099,12 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-meilisearch@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.23.0.tgz#eed5098bd147c13658c3f92e658df9cbfb9e8953"
-  integrity sha512-bLNonPJK2pJz2akjwolcc/Eqnz/GKJ7y1I4Flg4zjL+v0yPFyIGFFdfe0dw93JWFJWj/RbLS2Q6dDTobZQ9Ehg==
+meilisearch@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.27.0.tgz#8bd57ddb77b975f93e054cb977b951c488ece297"
+  integrity sha512-kZOZFIuSO7c6xRf+Y2/9/h6A9pl0sCl/G44X4KuaSwxGbruOZPhmxbeVEgLHBv4pUFvQ56rNVTA/2d/5GCU1YA==
   dependencies:
-    cross-fetch "^3.1.4"
+    cross-fetch "^3.1.5"
 
 memfs@^3.1.2:
   version "3.4.4"


### PR DESCRIPTION
Now that the demo-movies has been updated to v0.28.1, we can update the version of instant-meilisearch to v0.8.1. 
The index name of the demo-movies has also been updated to reflect the changes due to multilingualism