### PR TITLE
Add redirection for blog and docs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,18 @@ module.exports = {
         destination: '/privacy-policy',
         permanent: true,
       },
+      {
+        source: '/blog',
+        destination: 'https://blog.meilisearch.com',
+        permanent: true,
+        basePath: false,
+      },
+      {
+        source: '/docs',
+        destination: 'https://docs.meilisearch.com',
+        permanent: true,
+        basePath: false,
+      },
     ]
   },
 }


### PR DESCRIPTION
# Pull Request

## Related issue
People are looking to reach our blog, and our docs thought the main URL `meilisearch.com/blog` and `meilisearch.com/docs`, but it doesn't work. 

## What does this PR do?
- add two redirect configurations on the `next.config.js` file. 
