### PR TITLE
Add fallback fonts

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -8,10 +8,6 @@
   href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
   rel="stylesheet"
 />
-<link
-  href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;700&display=swap"
-  rel="stylesheet"
-/>
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/src/blocks/Developer/Terminal/LeftColumn.js
+++ b/src/blocks/Developer/Terminal/LeftColumn.js
@@ -24,7 +24,7 @@ const SdkTab = styled(Tab.Tab)`
 `
 
 const Language = styled(Typography)`
-  font-family: 'Poppins';
+  font-family: ${get('fontFamily.poppins')};
   font-weight: ${get('fontWeight.bold')};
   font-size: 10px;
   line-height: 12px;

--- a/src/blocks/OpenSource.js
+++ b/src/blocks/OpenSource.js
@@ -95,7 +95,7 @@ const Keypoint = styled.div`
 `
 
 const Number = styled.span`
-  font-family: Poppins;
+  font-family: ${get('fontFamily.poppins')};
   font-weight: ${get('fontWeight.bold')};
   letter-spacing: -0.02em;
   font-size: 50px;

--- a/src/components/InteractiveSearch.js
+++ b/src/components/InteractiveSearch.js
@@ -41,7 +41,7 @@ const Poster = styled.div`
 `
 
 const MovieTitle = styled(Typography)`
-  font-family: 'Poppins';
+  font-family: ${get('fontFamily.poppins')};
   font-weight: 600;
   font-size: 21.1092px;
   line-height: 32px;
@@ -54,7 +54,7 @@ const MovieTitle = styled(Typography)`
 `
 
 const MovieYear = styled.div`
-  font-family: Poppins;
+  font-family: ${get('fontFamily.poppins')};
   font-size: 12px;
   font-weight: 400;
   color: ${get('colors.valhalla.300')};
@@ -94,7 +94,7 @@ const Hit = ({ hit }) => (
 
 const StatsText = styled(Typography)`
   color: ${get('colors.white')};
-  font-family: Inter;
+  font-family: ${get('fontFamily.inter')};
   font-weight: ${get('fontWeight.normal')};
   font-size: 12px;
   line-height: 150%;

--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -7,7 +7,7 @@ import get from 'utils/get'
 const StyledMarkdown = styled.div`
   color: ${get('colors.ashes.900')};
   margin-top: 16px;
-  font-family: Inter;
+  font-family: ${get('fontFamily.inter')};
   word-break: break-word;
   h1 {
     color: ${get('colors.white')};

--- a/src/components/Searchbox.js
+++ b/src/components/Searchbox.js
@@ -54,7 +54,7 @@ const StyledSearchbox = styled(IsSearchbox)`
 
     ::placeholder {
       color: ${get('colors.valhalla.200')};
-      font-family: Inter;
+      font-family: ${get('fontFamily.inter')};
       font-weight: ${get('fontWeight.normal')};
       font-size: 14px;
       line-height: 150%;

--- a/src/components/Typography.js
+++ b/src/components/Typography.js
@@ -8,7 +8,7 @@ const variants = {
     xl: {
       tag: 'span',
       style: css`
-        font-family: Poppins;
+        font-family: ${get('fontFamily.poppins')};
         font-weight: 700;
         letter-spacing: -1%;
         line-height: 140%;
@@ -24,7 +24,7 @@ const variants = {
     l: {
       tag: 'span',
       style: css`
-        font-family: Poppins;
+        font-family: ${get('fontFamily.poppins')};
         font-weight: 700;
         letter-spacing: -1%;
         line-height: 140%;
@@ -40,7 +40,7 @@ const variants = {
     m: {
       tag: 'span',
       style: css`
-        font-family: Poppins;
+        font-family: ${get('fontFamily.poppins')};
         font-weight: 600;
         letter-spacing: -1%;
         line-height: 140%;
@@ -56,7 +56,7 @@ const variants = {
     s: {
       tag: 'span',
       style: css`
-        font-family: Poppins;
+        font-family: ${get('fontFamily.poppins')};
         font-weight: 600;
         letter-spacing: -1%;
         line-height: 140%;
@@ -72,7 +72,7 @@ const variants = {
     xs: {
       tag: 'span',
       style: css`
-        font-family: Poppins;
+        font-family: ${get('fontFamily.poppins')};
         font-weight: 500;
         line-height: 140%;
         font-size: 18px;
@@ -87,7 +87,7 @@ const variants = {
     caps: {
       tag: 'span',
       style: css`
-        font-family: Poppins;
+        font-family: ${get('fontFamily.poppins')};
         font-weight: 700;
         letter-spacing: 3%;
         line-height: 140%;
@@ -104,7 +104,7 @@ const variants = {
     capsXs: {
       tag: 'span',
       style: css`
-        font-family: Poppins;
+        font-family: ${get('fontFamily.poppins')};
         font-weight: 700;
         letter-spacing: 3%;
         line-height: 130%;
@@ -121,7 +121,7 @@ const variants = {
       default: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           line-height: 150%;
           font-size: 15px;
           font-weight: 400;
@@ -136,7 +136,7 @@ const variants = {
       bold: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           line-height: 150%;
           font-size: 15px;
           font-weight: 600;
@@ -151,7 +151,7 @@ const variants = {
       link: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           line-height: 150%;
           font-size: 15px;
           font-weight: 600;
@@ -169,7 +169,7 @@ const variants = {
       default: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           font-weight: 400;
           line-height: 150%;
           font-size: 14px;
@@ -184,7 +184,7 @@ const variants = {
       bold: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           font-weight: 600;
           line-height: 150%;
           font-size: 14px;
@@ -199,7 +199,7 @@ const variants = {
       link: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           font-weight: 600;
           line-height: 150%;
           font-size: 14px;
@@ -217,7 +217,7 @@ const variants = {
       default: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           font-weight: 400;
           line-height: 150%;
           font-size: 12px;
@@ -232,7 +232,7 @@ const variants = {
       bold: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           font-weight: 600;
           line-height: 150%;
           font-size: 12px;
@@ -247,7 +247,7 @@ const variants = {
       link: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           font-weight: 600;
           line-height: 150%;
           font-size: 12px;
@@ -265,7 +265,7 @@ const variants = {
       default: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           font-weight: 400;
           line-height: 150%;
           font-size: 10px;
@@ -280,7 +280,7 @@ const variants = {
       bold: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           font-weight: 600;
           line-height: 150%;
           font-size: 10px;
@@ -295,7 +295,7 @@ const variants = {
       link: {
         tag: 'span',
         style: css`
-          font-family: Inter;
+          font-family: ${get('fontFamily.inter')};
           font-weight: 600;
           line-height: 150%;
           text-decoration: underline;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -33,7 +33,7 @@ const PageContent = styled(BasePageContent)`
 `
 
 const Title = styled(Typography)`
-  font-family: Poppins;
+  font-family: ${get('fontFamily.poppins')};
   font-style: normal;
   font-weight: ${get('fontWeight.bold')};
   font-size: 172px;

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -47,10 +47,6 @@ class MyDocument extends Document {
             rel="stylesheet"
           />
           <link
-            href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;700&display=swap"
-            rel="stylesheet"
-          />
-          <link
             rel="apple-touch-icon"
             sizes="180x180"
             href="/apple-touch-icon.png"

--- a/src/theme/fontFamily.js
+++ b/src/theme/fontFamily.js
@@ -1,0 +1,6 @@
+const fontFamily = {
+  poppins: 'Poppins, Arial, Helvetica, sans-serif',
+  inter: 'Inter, Verdana, sans-serif',
+}
+
+export default fontFamily

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,11 +1,13 @@
 import colors from './colors'
 import fontWeight from './fontWeight'
 import breakpoints from './breakpoints'
+import fontFamily from './fontFamily'
 
 const theme = {
   breakpoints,
   colors,
   fontWeight,
+  fontFamily,
 }
 
 export default theme


### PR DESCRIPTION
Currently, we have an ugly `Times` font displaying first on page load, and then our custom font appear.

This PR adds fallback fonts in order to have a less ugly FOUT.

+ removal of the `Work Sans` font which wasn't used.