### PR TITLE
Add variables for header height

### DIFF
--- a/src/blocks/Header/MobileHeader.js
+++ b/src/blocks/Header/MobileHeader.js
@@ -31,7 +31,10 @@ const Backdrop = styled(DialogBackdrop)`
   color: ${get('colors.white')};
   background-color: ${get('colors.valhalla')};
   z-index: 50;
-  inset: ${p => (p.$hasBanner ? 'calc(98px + 72px) 0 0 0' : '98px 0 0 0')};
+  inset: ${p =>
+    p.$hasBanner
+      ? 'calc(var(--header-height-mobile) + var(--banner-height)) 0 0 0'
+      : 'var(--header-height-mobile) 0 0 0'};
   padding-top: 64px;
   @media (min-width: ${get('breakpoints.lg')}) {
     display: none;

--- a/src/blocks/Header/index.js
+++ b/src/blocks/Header/index.js
@@ -23,9 +23,9 @@ const HeaderWrapper = styled.div`
   width: 100%;
   background-color: ${p =>
     p.$hasDarkBgColor ? get('colors.valhalla.800') : get('colors.valhalla')};
-  height: 98px;
+  height: var(--header-height-mobile);
   @media (min-width: ${get('breakpoints.lg')}) {
-    height: 88px;
+    height: var(--header-height-desktop);
   }
 `
 

--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -6,7 +6,7 @@ import Typography from 'components/Typography'
 const Wrapper = styled.div`
   background-color: ${get('colors.dodgerBlue')};
   padding: 16px;
-  height: 72px;
+  height: var(--banner-height);
   color: white;
   display: flex;
   align-items: center;

--- a/src/layouts/LegalLayout.js
+++ b/src/layouts/LegalLayout.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import Grid from 'components/Grid'
 import get from 'utils/get'
 import hexToRgb from 'utils/hexToRgb'
+import getHeaderData from '../../data/header'
 
 const ResourceCenter = styled(Grid)`
   @media (min-width: ${get('breakpoints.lg')}) {
@@ -13,7 +14,10 @@ const ResourceCenter = styled(Grid)`
 const GridWrapper = styled.div`
   grid-column: 1 / -1;
   position: sticky;
-  top: 98px;
+  top: calc(
+    var(--header-height-mobile)
+      ${p => (p.$hasBanner ? '+ var(--banner-height)' : '')}
+  );
   height: 50px;
   margin: 0;
   padding: 0 16px;
@@ -36,18 +40,22 @@ const GridWrapper = styled.div`
 const StickyWrapper = styled.div`
   @media (min-width: ${get('breakpoints.md')}) {
     position: sticky;
-    top: calc(98px + 54px);
-  }
-  @media (min-width: ${get('breakpoints.lg')}) {
-    top: calc(88px + 54px);
+    top: calc(
+      var(--header-height-desktop) + 54px
+        ${p => (p.$hasBanner ? '+ var(--banner-height)' : '')}
+    );
   }
 `
 
-const LeftColumn = ({ children, ...props }) => (
-  <GridWrapper {...props}>
-    <StickyWrapper>{children}</StickyWrapper>
-  </GridWrapper>
-)
+const LeftColumn = ({ children, ...props }) => {
+  const { banner } = getHeaderData()
+
+  return (
+    <GridWrapper $hasBanner={banner.title} {...props}>
+      <StickyWrapper $hasBanner={banner.title}>{children}</StickyWrapper>
+    </GridWrapper>
+  )
+}
 
 const MiddleColumn = styled.div`
   grid-column: 1 / -1;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -5,16 +5,23 @@ import Button from 'components/Button'
 import Typography from 'components/Typography'
 import BasePageContent from 'components/PageContent'
 import get404Data from '../../data/404'
+import getHeaderData from '../../data/header'
 
 const Container = styled.div`
   height: 100vh;
-  margin-top: -98px;
+  margin-top: calc(
+    0px - var(--header-height-mobile)
+      ${p => (p.$hasBanner ? '- var(--banner-height)' : '')}
+  );
   display: flex;
   align-items: center;
   justify-content: center;
 
   @media (min-width: ${get('breakpoints.lg')}) {
-    margin-top: -88px;
+    margin-top: calc(
+      0px - var(--header-height-desktop)
+        ${p => (p.$hasBanner ? '- var(--banner-height)' : '')}
+    );
   }
 `
 
@@ -77,10 +84,12 @@ const Cta = styled.div`
 
 const Custom404 = () => {
   const { meta, content } = get404Data()
+  const { banner } = getHeaderData()
+
   return (
     <>
       <Head meta={meta} />
-      <Container>
+      <Container $hasBanner={banner}>
         <PageContent>
           <Text>
             <Title>404</Title>

--- a/src/theme/GlobalStyle.js
+++ b/src/theme/GlobalStyle.js
@@ -8,6 +8,9 @@ const GlobalStyle = createGlobalStyle`
     scroll-behavior: smooth;
     font-smooth: auto;
     -webkit-font-smoothing: antialiased;
+    --header-height-mobile: 98px;
+    --header-height-desktop: 88px;
+    --banner-height: 72px;
   }
   * {
     box-sizing: border-box;


### PR DESCRIPTION
# Pull Request

## What does this PR do?
With the addition of the banner on top of the header, some behaviours were broken. For example, on the legal pages, we have a sticky menu on the left which position is determined by the header height ; and which goes below the header on scroll because the header is now bigger (banner added).
Problem on video: 

https://user-images.githubusercontent.com/30866152/197784523-434afe82-3b04-4bd3-ac4c-1eabde303409.mov



In this PR, we have now a variable for the header height (both in mobile and desktop) + for the banner height, which is more maintainable than hard-coded values.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
