### PR TITLE
Remove .babelrc file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": ["babel-plugin-macros", ["styled-components", { "ssr": true }]]
-}

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   reactStrictMode: true,
+  compiler: {
+    styledComponents: true,
+  },
   poweredByHeader: false,
   webpack: config => {
     // Unset client-side javascript that only works server-side

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@storybook/addon-links": "^6.5.12",
     "@storybook/react": "^6.5.12",
     "babel-loader": "^8.2.4",
-    "babel-plugin-macros": "^3.1.0",
     "cypress": "^10.10.0",
     "eslint": "8.21.0",
     "eslint-config-next": "12.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4677,7 +4677,7 @@ babel-plugin-istanbul@^6.0.0:
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
 
-babel-plugin-macros@^3.0.1, babel-plugin-macros@^3.1.0:
+babel-plugin-macros@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
   integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==


### PR DESCRIPTION
Since its v12.1, Next JS supports styled-components with its new compiler (SWC).
Therefore, we don't need the `.babelrc` file, nor the `babel-plugin-macros` dependency.
See also [https://nextjs.org/docs/advanced-features/compiler#styled-components](https://nextjs.org/docs/advanced-features/compiler#styled-components) for more information